### PR TITLE
fix(mergeConfig): respect referenceActions option

### DIFF
--- a/lib/merge-config.js
+++ b/lib/merge-config.js
@@ -211,7 +211,7 @@ function mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts
         },
         parserOpts);
 
-      if (hostOpts.referenceActions && parserOpts) {
+      if (!parserOpts.hasOwnProperty('referenceActions') && hostOpts.referenceActions) {
         parserOpts.referenceActions = hostOpts.referenceActions;
       }
 

--- a/test/test.js
+++ b/test/test.js
@@ -419,6 +419,30 @@ describe('conventionalChangelogCore', function() {
     }));
   });
 
+  it('should use custom referenceActions if a `referenceActions` is provided in the `options.config.parserOpts` object', function(done) {
+    gitDummyCommit('Custom prefix closes #42');
+    gitDummyCommit('Old prefix #71');
+
+    conventionalChangelogCore({
+      config: {
+        parserOpts: null
+      }}, {
+      host: 'github',
+      owner: 'b',
+      repository: 'a'
+    }, {}, {
+      issuePrefixes: ['#']
+    }).pipe(through(function(chunk) {
+      chunk = chunk.toString();
+
+      expect(chunk).to.include('](github/b/a/commit/');
+      expect(chunk).to.include('closes [#42](github/b/a/issues/42)');
+      expect(chunk).to.include('closes [#71](github/b/a/issues/71)');
+
+      done();
+    }));
+  });
+
   it('should read github\'s host configs', function(done) {
     preparing(5);
 


### PR DESCRIPTION
hostsOpts forcefully overrides configuration referenceActions.

example:
I define a preset with `referenceActions: null`
`mergeConfig` overrides the option with the defaults for the repo host 
no way provided to avoid this override.
