### PR TITLE
feat(context): Add "host_[host]" property for templates

### DIFF
--- a/lib/merge-config.js
+++ b/lib/merge-config.js
@@ -183,6 +183,9 @@ function mergeConfig(options, context, gitRawCommitsOpts, parserOpts, writerOpts
             issue: hostOpts.issue,
             commit: hostOpts.commit
           }, context);
+
+          // Add a property like 'host_bitbucket' so it can be used for custom templates
+          context['host_' + type] = true;
         } else {
           options.warn('Host: "' + context.host + '" does not exist');
           hostOpts = {};


### PR DESCRIPTION
As said in the comment:
This new boolean property will be based on the context.host, and only if it is a valid host:
- host_github: true for GitHub hosts
- host_bitbucket: true for BitBucket hosts
- host_gitlab: true for GitLab hosts
  With this, custom templates can use it to, for example, change the tag comparison link:

``` handlebars
  {{~#if @root.host~}}
    {{~#if @root.host_bitbucket~}} {{~!-- BitBucket makes the comparision with two dots --}}
      /compare/{{previousTag}}..{{currentTag}})
    {{~else~}}
      /compare/{{previousTag}}...{{currentTag}})
    {{~/if~}}
  {{~else~}}
    /compare/{{previousTag}}...{{currentTag}})
  {{~/if~}}
```

This is meant to a following pull request on conventional-changelog-angular for having valid link by default for bitbucket, so we don't have to override allways the header template
