### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+test/
+.gitattributes
+.gitignore
+.jscsrc
+.jshintrc
+.travis.yml
+CHANGELOG.md
+appveyor.yml


### PR DESCRIPTION
[x] Reduces package bundle size as unnecessary for production files are trimmed from the package.

[x] Fixes flow-type breaking on packages that have this package in `node_modules` due to the error:

```
$ flow .
node_modules/conventional-changelog-core/test/fixtures/_malformation.json:1
  1: 
     ^ Unexpected end of input


Found 1 error
```